### PR TITLE
Fix script paths for root execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # KJV_1611
-creating a language model using the King James Bible 1611 as the sole source of knowledge
+Creating a language model using the King James Bible 1611 as the sole source of knowledge.
+
+## Usage
+
+Install the required dependencies and run the scripts from the repository root:
+
+```bash
+pip install -r requirements.txt
+python scripts/data_preprocessing.py
+python scripts/build_language_model.py
+```

--- a/scripts/build_language_model.py
+++ b/scripts/build_language_model.py
@@ -6,7 +6,7 @@ model = GPT2LMHeadModel.from_pretrained(model_name)
 tokenizer = GPT2Tokenizer.from_pretrained(model_name)
 
 # Load preprocessed text
-with open('../data/kjv_1611.txt', 'r', encoding='utf-8') as file:
+with open('data/kjv_1611.txt', 'r', encoding='utf-8') as file:
     text = file.read()
 
 # Tokenize the Bible text
@@ -14,8 +14,8 @@ inputs = tokenizer(text, return_tensors='pt', max_length=512, truncation=True)
 
 # Fine-tune the model
 training_args = TrainingArguments(
-    output_dir='../models/',
-    logging_dir='../logs/',
+    output_dir='models/',
+    logging_dir='logs/',
     logging_steps=100,
     overwrite_output_dir=True,
     num_train_epochs=1,

--- a/scripts/data_preprocessing.py
+++ b/scripts/data_preprocessing.py
@@ -1,7 +1,7 @@
 import re
 
 # Load the KJV Bible text
-with open('../data/kjv_1611.txt', 'r', encoding='utf-8') as file:
+with open('data/kjv_1611.txt', 'r', encoding='utf-8') as file:
     text = file.read()
 
 # Simple preprocessing: remove non-alphanumeric characters, convert to lowercase
@@ -13,5 +13,5 @@ words = text.split()
 print(f"Total words in KJV Bible: {len(words)}")
 
 # Save preprocessed text if needed
-with open('../data/kjv_1611_preprocessed.txt', 'w', encoding='utf-8') as file:
+with open('data/kjv_1611_preprocessed.txt', 'w', encoding='utf-8') as file:
     file.write(' '.join(words))

--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -1,7 +1,7 @@
 from transformers import GPT2LMHeadModel, GPT2Tokenizer
 
 # Load model and tokenizer
-model = GPT2LMHeadModel.from_pretrained('../models/kjv_language_model')
+model = GPT2LMHeadModel.from_pretrained('models/kjv_language_model')
 tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
 
 def evaluate_model(text, model, tokenizer):

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -1,7 +1,7 @@
 from transformers import GPT2Tokenizer, GPT2LMHeadModel
 
 # Load the trained model
-model = GPT2LMHeadModel.from_pretrained('../models/kjv_language_model')
+model = GPT2LMHeadModel.from_pretrained('models/kjv_language_model')
 tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
 
 def generate_text(prompt, max_length=50):

--- a/scripts/save_and_load_model.py
+++ b/scripts/save_and_load_model.py
@@ -1,9 +1,9 @@
 from transformers import GPT2LMHeadModel
 
 # Save the model
-def save_model(model, path='../models/kjv_language_model'):
+def save_model(model, path='models/kjv_language_model'):
     model.save_pretrained(path)
 
 # Load the model
-def load_model(path='../models/kjv_language_model'):
+def load_model(path='models/kjv_language_model'):
     return GPT2LMHeadModel.from_pretrained(path)


### PR DESCRIPTION
## Summary
- correct data/model paths in scripts to run from repository root
- update README with basic usage

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/data_preprocessing.py | head -n 20`
- `python scripts/inference.py | head -n 20` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_684c7629ff4083288a6a06240c1b8cc9