### PR TITLE
Simplify training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # KJV_1611
-creating a language model using the King James Bible 1611 as the sole source of knowledge
+Creating a language model using the King James Bible 1611 as the sole source of knowledge.
+
+## Usage
+
+Install the required dependencies and run the scripts from the repository root:
+
+```bash
+pip install -r requirements.txt
+python scripts/data_preprocessing.py
+python scripts/build_language_model.py
+python scripts/inference.py
+python scripts/evaluate_model.py
+```
+
+If you encounter an error such as `ModuleNotFoundError: No module named 'transformers'`,
+ensure that the dependencies were installed successfully. Network restrictions
+may prevent `pip` from downloading packages, so download them offline if
+necessary. The training script performs a very small update to avoid issues
+with PyTorch's distributed features. For full training you may need a complete
+PyTorch installation with `torch.distributed` support.

--- a/commands.txt
+++ b/commands.txt
@@ -1,8 +1,14 @@
+# Install dependencies
+pip install -r requirements.txt
+
+# If installation fails due to network restrictions,
+# download the required packages offline and install them locally.
+
 # Preprocess the data
 python scripts/data_preprocessing.py
 
 # Train the model
-python scripts/build_language_model.py
+python scripts/build_language_model.py  # minimal training step
 
 # Monitor training (in a new terminal)
 tensorboard --logdir=logs/
@@ -12,6 +18,3 @@ python scripts/inference.py
 
 # Evaluate the model
 python scripts/evaluate_model.py
-
-Testing 
-

--- a/scripts/data_preprocessing.py
+++ b/scripts/data_preprocessing.py
@@ -1,7 +1,7 @@
 import re
 
 # Load the KJV Bible text
-with open('../data/kjv_1611.txt', 'r', encoding='utf-8') as file:
+with open('data/kjv_1611.txt', 'r', encoding='utf-8') as file:
     text = file.read()
 
 # Simple preprocessing: remove non-alphanumeric characters, convert to lowercase
@@ -13,5 +13,5 @@ words = text.split()
 print(f"Total words in KJV Bible: {len(words)}")
 
 # Save preprocessed text if needed
-with open('../data/kjv_1611_preprocessed.txt', 'w', encoding='utf-8') as file:
+with open('data/kjv_1611_preprocessed.txt', 'w', encoding='utf-8') as file:
     file.write(' '.join(words))

--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -1,7 +1,12 @@
-from transformers import GPT2LMHeadModel, GPT2Tokenizer
+try:
+    from transformers import GPT2LMHeadModel, GPT2Tokenizer
+except ImportError as exc:
+    raise ImportError(
+        "The 'transformers' package is required. Install dependencies with \"pip install -r requirements.txt\"."
+    ) from exc
 
 # Load model and tokenizer
-model = GPT2LMHeadModel.from_pretrained('../models/kjv_language_model')
+model = GPT2LMHeadModel.from_pretrained('models/kjv_language_model')
 tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
 
 def evaluate_model(text, model, tokenizer):

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -1,7 +1,12 @@
-from transformers import GPT2Tokenizer, GPT2LMHeadModel
+try:
+    from transformers import GPT2Tokenizer, GPT2LMHeadModel
+except ImportError as exc:
+    raise ImportError(
+        "The 'transformers' package is required. Install dependencies with \"pip install -r requirements.txt\"."
+    ) from exc
 
 # Load the trained model
-model = GPT2LMHeadModel.from_pretrained('../models/kjv_language_model')
+model = GPT2LMHeadModel.from_pretrained('models/kjv_language_model')
 tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
 
 def generate_text(prompt, max_length=50):

--- a/scripts/save_and_load_model.py
+++ b/scripts/save_and_load_model.py
@@ -1,9 +1,14 @@
-from transformers import GPT2LMHeadModel
+try:
+    from transformers import GPT2LMHeadModel
+except ImportError as exc:
+    raise ImportError(
+        "The 'transformers' package is required. Install dependencies with \"pip install -r requirements.txt\"."
+    ) from exc
 
 # Save the model
-def save_model(model, path='../models/kjv_language_model'):
+def save_model(model, path='models/kjv_language_model'):
     model.save_pretrained(path)
 
 # Load the model
-def load_model(path='../models/kjv_language_model'):
+def load_model(path='models/kjv_language_model'):
     return GPT2LMHeadModel.from_pretrained(path)


### PR DESCRIPTION
## Summary
- avoid huggingface Trainer to prevent DTensor import error
- clarify README about minimal training and distributed requirements
- note minimal training step in `commands.txt`

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/data_preprocessing.py | head -n 20`
- `python scripts/inference.py | head -n 20` *(fails: ImportError about missing `transformers`)*

------
https://chatgpt.com/codex/tasks/task_e_684c7629ff4083288a6a06240c1b8cc9